### PR TITLE
Add alias field to `Bug`

### DIFF
--- a/src/bug_model.rs
+++ b/src/bug_model.rs
@@ -66,6 +66,7 @@ pub enum Version {
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct Bug {
+    pub alias: Vec<String>,
     pub op_sys: String,
     pub classification: String,
     pub id: i32,


### PR DESCRIPTION
Add a missing field that Bugzilla will return:

https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug